### PR TITLE
Fix bug in ADC implementation. Add test.

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -29,7 +29,7 @@ function initialize() {
     exit 1
   fi
 
-  if [ -n "${BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE}" ]; then
+  if [ -v BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE ]; then
     gcloud auth activate-service-account --key-file "${BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE}"
   fi
 

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -33,3 +33,25 @@ environment_hook="$PWD/hooks/environment"
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
 }
+
+@test "Fetches values from GCP Secret Manager into env via Application Default Credentials" {
+  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="secret1"
+
+  stub which \
+    "gcloud : echo /test/gcloud" \
+    "jq : echo /test/jq"
+
+  stub gcloud \
+    "secrets versions list secret1 --format=json : echo '[{\"name\":\"secret1/versions/10\"}]'" \
+    "secrets versions access 10 --secret=secret1 '--format=get(payload.data)' : echo 'dGVzdC12YWx1ZTEK'"
+
+  run "${environment_hook}"
+
+  assert_success
+  assert_output --partial "Exporting secret secret1 from GCP Secret Manager into environment variable TARGET1"
+
+  unstub gcloud
+  unstub which
+
+  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
+}


### PR DESCRIPTION
This fixes the bug where an unset 'files:' entry would cause the plugin to fail. A workaround for the bug is to set the 'files:' value to the empty string.

This patch corrects this bug and adds the test that should have existed anyway to check the correctness of the impementation.