### PR TITLE
Simplify getting the secret value

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -50,18 +50,9 @@ function load_secret_into_env() {
 
 function get_secret_value() {
   local secret_name="$1"
-  local secret_version
   local secret_value
 
-  secret_version=$(gcloud secrets versions list "${secret_name}" --format=json | jq -r '.[0].name')
-  secret_version="${secret_version##*/}"
-
-  local result=$?
-  if [[ $result -ne 0 ]]; then
-    exit 1
-  fi
-
-  secret_value=$(gcloud secrets versions access "${secret_version}" \
+  secret_value=$(gcloud secrets versions access latest \
     --secret="${secret_name}" \
     --format='get(payload.data)' | tr '_-' '/+' | base64 -d)
 


### PR DESCRIPTION
instead of listing the versions, just use 'latest'

This also simplifies the GCP setup and allows to use the [roles/secretmanager.secretAccessor](https://cloud.google.com/secret-manager/docs/access-control) role

Closes https://github.com/avaly/gcp-secret-manager-buildkite-plugin/issues/4