### PR TITLE
feat: add support for fully qualified secret names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Secret Accessor role for the secret being accessed (`roles/secretmanager.secretA
 ### `env` (object)
 
 An object defining the export variables names and the secret names which will populate the values.
+The secret names can be fully qualified names in the form of `projects/{project-id-or-number}/secrets/{secret-name}/versions/{version}`.
+`/versions/{version}` is optional. If not part of the fully quailified name the `/versions/latest` will be used.
 
 ## Developing
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -50,14 +50,31 @@ function load_secret_into_env() {
 
 function get_secret_value() {
   local secret_name="$1"
+  local secret_version="latest"
   local secret_value
 
-  secret_value=$(gcloud secrets versions access latest \
-    --secret="${secret_name}" \
-    --format='get(payload.data)' | tr '_-' '/+' | base64 -d)
+  
+
+  if [[ "${secret_name:-}" =~ ^projects/[a-z0-9-]+/secrets/([a-zA-Z0-9_-]+)(/versions/.+)?$ ]]; then
+    # secret_name is a fqn, set secret_name to the extracted name and set secret_version to the fqn
+    secret_version="${secret_name}"
+    secret_name=${BASH_REMATCH[1]}
+    local version=${BASH_REMATCH[2]}
+    
+    # if the fqn does not contain a version, set secret_version to latest
+    if [[ -z "${version}" ]]; then
+      secret_version="${secret_version}/versions/latest"
+    fi
+  fi
+
+  secret_value=$(gcloud secrets versions access "${secret_version}" \
+      --secret="${secret_name}" \
+      --format='get(payload.data)' | tr '_-' '/+' | base64 -d)
 
   result=$?
   if [[ $result -ne 0 ]]; then
+    echo "Failed to access secret ${secret_name} (${secret_version})"
+    echo "Please check if the secret exists and if the service account has access to it."
     exit 1
   fi
 

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -22,6 +22,14 @@ function stub_gcloud_secrets() {
     "secrets versions access latest --secret=secret2 '--format=get(payload.data)' : echo 'dGVzdC12YWx1ZTI='"
 }
 
+function stub_gcloud_secrets_fqn() {
+  local project=$1
+
+  stub gcloud \
+    "secrets versions access projects/${project}/secrets/SECRET_NAME1/versions/latest --secret=SECRET_NAME1 '--format=get(payload.data)' : echo 'dGVzdC12YWx1ZTEK'" \
+    "secrets versions access projects/${project}/secrets/SECRET_NAME2/versions/1 --secret=SECRET_NAME2 '--format=get(payload.data)' : echo 'dGVzdC12YWx1ZTI='" 
+}
+
 environment_hook="$PWD/hooks/environment"
 
 @test "Exports values from GCP Secret Manager into env - output" {
@@ -92,4 +100,48 @@ environment_hook="$PWD/hooks/environment"
 
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2
+}
+
+
+@test "Supports fully qualified names without version" {
+  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="projects/test-project/secrets/SECRET_NAME1"
+
+  stub_gcloud_secrets_fqn test-project
+
+  # Using `run` will not populate these variables in the current shell
+  source "${environment_hook}"
+
+  assert_equal $TARGET1 "test-value1"
+
+  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
+}
+
+@test "Supports fully qualified names with specific version" {
+  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="projects/test-project/secrets/SECRET_NAME1/versions/latest"
+  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2="projects/test-project/secrets/SECRET_NAME2/versions/1"
+
+  stub_gcloud_secrets_fqn test-project
+
+  # Using `run` will not populate these variables in the current shell
+  source "${environment_hook}"
+
+  assert_equal $TARGET1 "test-value1"
+  assert_equal $TARGET2 "test-value2"
+
+  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
+  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2
+}
+
+
+@test "Supports fully qualified names with project number" {
+  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="projects/01726654/secrets/SECRET_NAME1"
+
+  stub_gcloud_secrets_fqn 01726654
+
+  # Using `run` will not populate these variables in the current shell
+  source "${environment_hook}"
+
+  assert_equal $TARGET1 "test-value1"
+
+  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
 }


### PR DESCRIPTION
This adds support for fully qualified secret names to allow passing different projects.
E.g. if the CI needs secrets from different projects (shared CI project and staging/prod projects).

Closes #6 