### PR TITLE
feat: redact secrets

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -46,6 +46,7 @@ function load_secret_into_env() {
   # Redact secrets (https://buildkite.com/docs/agent/v3/cli-redactor) was added
   # in https://github.com/buildkite/agent/releases/tag/v3.66.0)
   echo "Redacting secret in Buildkite logs"
+  set +x # let's play safe and disable command tracing
   if ! echo "${secret_value}" | buildkite-agent redactor add ; then
     echo "Secret could not be redacted in Buildkite logs. Please ensure the Buildkite agent redactor is configured correctly."
   fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -43,6 +43,13 @@ function load_secret_into_env() {
 
   secret_value="$(get_secret_value "${secret_name}")"
 
+  # Redact secrets (https://buildkite.com/docs/agent/v3/cli-redactor) was added
+  # in https://github.com/buildkite/agent/releases/tag/v3.66.0)
+  echo "Redacting secret in Buildkite logs"
+  if ! echo "${secret_value}" | buildkite-agent redactor add ; then
+    echo "Secret could not be redacted in Buildkite logs. Please ensure the Buildkite agent redactor is configured correctly."
+  fi
+
   echo "Exporting secret ${secret_name} from GCP Secret Manager into environment variable ${export_name}"
 
   export "${export_name}=${secret_value}"

--- a/hooks/environment
+++ b/hooks/environment
@@ -35,9 +35,10 @@ function redact_secret() {
   local secret_value="$1"
   local export_name="$2"
 
-  echo "Redacting secret in Buildkite logs for ${export_name}"
-  if ! echo "${secret_value}" | buildkite-agent redactor add ; then
-    echo "Warning: Buildkite agent redactor is not configured. Secrets will not be redacted in logs."
+  if echo "${secret_value}" | buildkite-agent redactor add ; then
+    echo "Redacting secret in Buildkite logs for ${export_name}"
+  else
+    echo "Warning: Buildkite agent redactor is not configured. The value for ${export_name} will not be redacted in logs."
   fi
 }
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -33,8 +33,9 @@ function initialize() {
 # in https://github.com/buildkite/agent/releases/tag/v3.66.0)
 function redact_secret() {
   local secret_value="$1"
+  local export_name="$2"
 
-  echo "Redacting secret in Buildkite logs"
+  echo "Redacting secret in Buildkite logs for ${export_name}"
   if ! echo "${secret_value}" | buildkite-agent redactor add ; then
     echo "Warning: Buildkite agent redactor is not configured. Secrets will not be redacted in logs."
   fi
@@ -47,7 +48,7 @@ function load_secret_into_env() {
 
   secret_value="$(get_secret_value "${secret_name}")"
 
-  redact_secret "${secret_value}"
+  redact_secret "${secret_value}" "${export_name}"
 
   echo "Exporting secret ${secret_name} from GCP Secret Manager into environment variable ${export_name}"
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -29,6 +29,17 @@ function initialize() {
   initialized="1"
 }
 
+# Redact secrets (https://buildkite.com/docs/agent/v3/cli-redactor) was added
+# in https://github.com/buildkite/agent/releases/tag/v3.66.0)
+function redact_secret() {
+  local secret_value="$1"
+
+  echo "Redacting secret in Buildkite logs"
+  if ! echo "${secret_value}" | buildkite-agent redactor add ; then
+    echo "Warning: Buildkite agent redactor is not configured. Secrets will not be redacted in logs."
+  fi
+}
+
 function load_secret_into_env() {
   local export_name="$1"
   local secret_name="$2"
@@ -36,13 +47,7 @@ function load_secret_into_env() {
 
   secret_value="$(get_secret_value "${secret_name}")"
 
-  # Redact secrets (https://buildkite.com/docs/agent/v3/cli-redactor) was added
-  # in https://github.com/buildkite/agent/releases/tag/v3.66.0)
-  echo "Redacting secret in Buildkite logs"
-  set +x # let's play safe and disable command tracing
-  if ! echo "${secret_value}" | buildkite-agent redactor add ; then
-    echo "Secret could not be redacted in Buildkite logs. Please ensure the Buildkite agent redactor is configured correctly."
-  fi
+  redact_secret "${secret_value}"
 
   echo "Exporting secret ${secret_name} from GCP Secret Manager into environment variable ${export_name}"
 

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -5,14 +5,11 @@ setup() {
 
   # Uncomment to enable stub debugging
   # export GCLOUD_STUB_DEBUG=/dev/tty
-  export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
-  export ECHO_STUB_DEBUG=/dev/tty
+  # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+  # export ECHO_STUB_DEBUG=/dev/tty
 
   stub which \
     "gcloud : echo /test/gcloud"
-
-  stub buildkite-agent \
-    'exit 0'
 
   stub echo \
     'exit 0'
@@ -38,6 +35,12 @@ function stub_gcloud_secrets_fqn() {
     "secrets versions access projects/${project}/secrets/SECRET_NAME2/versions/1 --secret=SECRET_NAME2 '--format=get(payload.data)' : echo 'dGVzdC12YWx1ZTI='"
 }
 
+function stub_buildkite_agent() {
+  stub buildkite-agent \
+    'exit 0' \
+    'exit 0'
+}
+
 environment_hook="$PWD/hooks/environment"
 
 @test "Exports values from GCP Secret Manager into env - output" {
@@ -45,6 +48,7 @@ environment_hook="$PWD/hooks/environment"
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="secret1"
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2="secret2"
 
+  stub_buildkite_agent
   stub gcloud "auth activate-service-account --key-file /tmp/credentials.json : "
   stub_gcloud_secrets
 
@@ -53,26 +57,9 @@ environment_hook="$PWD/hooks/environment"
   assert_success
   assert_output --partial "Exporting secret secret1 from GCP Secret Manager into environment variable TARGET1"
   assert_output --partial "Exporting secret secret2 from GCP Secret Manager into environment variable TARGET2"
-  assert_output --partial "Redacting secret in Buildkite logs"
-
-  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE
-  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
-  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2
-}
-
-@test "Fetches values from GCP Secret Manager into env - variables" {
-  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE="/tmp/credentials.json"
-  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="secret1"
-  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2="secret2"
-
-  stub gcloud "auth activate-service-account --key-file /tmp/credentials.json : "
-  stub_gcloud_secrets
-
-  # Using `run` will not populate these variables in the current shell
-  source "${environment_hook}"
-
-  assert_equal $TARGET1 "test-value1"
-  assert_equal $TARGET2 "test-value2"
+  assert_output --partial "Redacting secret in Buildkite logs for TARGET1"
+  assert_output --partial "Redacting secret in Buildkite logs for TARGET2"
+  refute_output --partial 'Warning: Buildkite agent redactor is not configured'
 
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
@@ -83,6 +70,7 @@ environment_hook="$PWD/hooks/environment"
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="secret1"
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2="secret2"
 
+  stub_buildkite_agent
   stub_gcloud_secrets
 
   run "${environment_hook}"
@@ -90,6 +78,9 @@ environment_hook="$PWD/hooks/environment"
   assert_success
   assert_output --partial "Exporting secret secret1 from GCP Secret Manager into environment variable TARGET1"
   assert_output --partial "Exporting secret secret2 from GCP Secret Manager into environment variable TARGET2"
+  assert_output --partial "Redacting secret in Buildkite logs for TARGET1"
+  assert_output --partial "Redacting secret in Buildkite logs for TARGET2"
+  refute_output --partial 'Warning: Buildkite agent redactor is not configured'
 
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2
@@ -99,6 +90,7 @@ environment_hook="$PWD/hooks/environment"
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="secret1"
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2="secret2"
 
+  stub_buildkite_agent
   stub_gcloud_secrets
 
   # Using `run` will not populate these variables in the current shell
@@ -114,6 +106,7 @@ environment_hook="$PWD/hooks/environment"
 @test "Supports fully qualified names without version" {
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="projects/test-project/secrets/SECRET_NAME1"
 
+  stub_buildkite_agent
   stub_gcloud_secrets_fqn test-project
 
   # Using `run` will not populate these variables in the current shell
@@ -128,6 +121,7 @@ environment_hook="$PWD/hooks/environment"
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="projects/test-project/secrets/SECRET_NAME1/versions/latest"
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET2="projects/test-project/secrets/SECRET_NAME2/versions/1"
 
+  stub_buildkite_agent
   stub_gcloud_secrets_fqn test-project
 
   # Using `run` will not populate these variables in the current shell
@@ -143,6 +137,7 @@ environment_hook="$PWD/hooks/environment"
 @test "Supports fully qualified names with project number" {
   export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="projects/01726654/secrets/SECRET_NAME1"
 
+  stub_buildkite_agent
   stub_gcloud_secrets_fqn 01726654
 
   # Using `run` will not populate these variables in the current shell
@@ -168,10 +163,9 @@ environment_hook="$PWD/hooks/environment"
 
   assert_success
   assert_output --partial "Exporting secret secret1 from GCP Secret Manager into environment variable TARGET1"
-  assert_output --partial "Redacting secret in Buildkite logs"
+  assert_output --partial "Buildkite agent redactor is not configured. The value for TARGET1 will not be redacted in logs"
+  refute_output --partial "Redacting secret in Buildkite logs for TARGET1"
 
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
-
-  unstub buildkite-agent
 }

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -5,12 +5,21 @@ setup() {
 
   # Uncomment to enable stub debugging
   # export GCLOUD_STUB_DEBUG=/dev/tty
+  export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+  export ECHO_STUB_DEBUG=/dev/tty
 
   stub which \
     "gcloud : echo /test/gcloud"
+
+  stub buildkite-agent \
+    'exit 0'
+
+  stub echo \
+    'exit 0'
 }
 
 teardown() {
+  unstub buildkite-agent
   unstub gcloud
   unstub which
 }
@@ -44,6 +53,7 @@ environment_hook="$PWD/hooks/environment"
   assert_success
   assert_output --partial "Exporting secret secret1 from GCP Secret Manager into environment variable TARGET1"
   assert_output --partial "Exporting secret secret2 from GCP Secret Manager into environment variable TARGET2"
+  assert_output --partial "Redacting secret in Buildkite logs"
 
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
@@ -141,4 +151,27 @@ environment_hook="$PWD/hooks/environment"
   assert_equal $TARGET1 "test-value1"
 
   unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
+}
+
+@test "Supports non redacted" {
+  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE="/tmp/credentials.json"
+  export BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1="secret1"
+
+  stub gcloud "auth activate-service-account --key-file /tmp/credentials.json : "
+  stub_gcloud_secrets
+  stub buildkite-agent \
+      'exit 1'
+  stub echo \
+      'exit 1'
+
+  run "${environment_hook}"
+
+  assert_success
+  assert_output --partial "Exporting secret secret1 from GCP Secret Manager into environment variable TARGET1"
+  assert_output --partial "Redacting secret in Buildkite logs"
+
+  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_CREDENTIALS_FILE
+  unset BUILDKITE_PLUGIN_GCP_SECRET_MANAGER_ENV_TARGET1
+
+  unstub buildkite-agent
 }


### PR DESCRIPTION
uses https://buildkite.com/docs/agent/v3/cli-redactor that has been enabled at https://github.com/buildkite/agent/pull/2660


This should be a best-effort approach, so if it cannot be redacted then it should actually keep working - so this plugin can still work with previous buildkite-agent versions.

uses buildkite/agent#2660

### Tests

I tested my branch and it worked fine

<img width="1390" height="634" alt="image" src="https://github.com/user-attachments/assets/332e2fc7-7751-489a-9acf-948dff6f390e" />
