### PR TITLE
fix: encoded content does not contain the padding characters needed for the base64 command

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -51,6 +51,8 @@ function load_secret_into_env() {
 function get_secret_value() {
   local secret_name="$1"
   local secret_value
+  # Create a temporary directory with both BSD and GNU mktemp
+  TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'buildkiteXXXX')
   local SECRETS_TMP_FILE="$TMPDIR"/secrets.tmp
 
   gcloud secrets versions access latest --secret="${secret_name}" --out-file="${SECRETS_TMP_FILE}"


### PR DESCRIPTION
Support windows when the encoded output is not with the padding characters.

Otherwise:

<img width="275" alt="image" src="https://github.com/user-attachments/assets/a63c9bcc-163c-4143-8411-74404d4fbf7a" />

According to the cloud docs:

```
EXAMPLES
    Access the data for version 123 of the secret 'my-secret':

        $ gcloud secrets versions access 123 --secret=my-secret

    Note: The output will be formatted as UTF-8 which can corrupt binary
    secrets.

    To write raw bytes to a file use --out-file flag:

        $ gcloud secrets versions access 123 --secret=my-secret \
            --out-file=/tmp/secret

    To get the raw bytes, have Google Cloud CLI print the response as
    base64-encoded and decode:

        $ gcloud secrets versions access 123 --secret=my-secret \
            --format='get(payload.data)' | tr '_-' '/+' | base64 -d
```

Further details:
- https://unix.stackexchange.com/questions/631501/base64-d-decodes-but-says-invalid-input


